### PR TITLE
Array#in_groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ require "crystal_on_steroids"
 * split
 * from
 * to
+* in_groups
 
 **Hash**
 

--- a/spec/array_spec.cr
+++ b/spec/array_spec.cr
@@ -87,4 +87,33 @@ describe Array do
       (1..10).to_a.split { |i| i % 3 == 0 }.should eq([[1, 2], [4, 5], [7, 8], [10]])
     end
   end
+
+  describe "in_groups" do
+    it "should split as three arrays with nil for filler elements to match length" do
+      array = %w(1 2 3 4 5 6 7 8 9 10)
+      result = [["1", "2", "3", "4"],
+                ["5", "6", "7", nil],
+                ["8", "9", "10", nil]]
+
+      array.in_groups(3).should eq(result)
+    end
+
+    it "should split as three arrays with filler elements to match length" do
+      array = %w(1 2 3 4 5 6 7 8 9 10)
+      result = [["1", "2", "3", "4"],
+                ["5", "6", "7", "&nbsp;"],
+                ["8", "9", "10", "&nbsp;"]]
+
+      array.in_groups(3, "&nbsp;").should eq(result)
+    end
+
+    it "should split as three arrays with no filler elements" do
+      array = %w(1 2 3 4 5 6 7 8 9 10)
+      result = [["1", "2", "3", "4"],
+                ["5", "6", "7"],
+                ["8", "9", "10"]]
+
+      array.in_groups(3, false).should eq(result)
+    end
+  end
 end

--- a/src/crystal_on_steroids/array.cr
+++ b/src/crystal_on_steroids/array.cr
@@ -142,6 +142,7 @@ class Array(T)
   # Splits or iterates over the array in +number+ of groups, padding any
   # remaining slots with +fill_with+ unless it is +false+.
   #
+  # ```
   #   %w(1 2 3 4 5 6 7 8 9 10).in_groups(3) {|group| p group}
   #   ["1", "2", "3", "4"]
   #   ["5", "6", "7", nil]
@@ -156,6 +157,7 @@ class Array(T)
   #   ["1", "2", "3"]
   #   ["4", "5"]
   #   ["6", "7"]
+  # ```
   #
   def in_groups(number, fill_with = nil)
     division = size / number

--- a/src/crystal_on_steroids/array.cr
+++ b/src/crystal_on_steroids/array.cr
@@ -138,4 +138,60 @@ class Array(T)
     end
     result << arr
   end
+
+  # Splits or iterates over the array in +number+ of groups, padding any
+  # remaining slots with +fill_with+ unless it is +false+.
+  #
+  #   %w(1 2 3 4 5 6 7 8 9 10).in_groups(3) {|group| p group}
+  #   ["1", "2", "3", "4"]
+  #   ["5", "6", "7", nil]
+  #   ["8", "9", "10", nil]
+  #
+  #   %w(1 2 3 4 5 6 7 8 9 10).in_groups(3, '&nbsp;') {|group| p group}
+  #   ["1", "2", "3", "4"]
+  #   ["5", "6", "7", "&nbsp;"]
+  #   ["8", "9", "10", "&nbsp;"]
+  #
+  #   %w(1 2 3 4 5 6 7).in_groups(3, false) {|group| p group}
+  #   ["1", "2", "3"]
+  #   ["4", "5"]
+  #   ["6", "7"]
+  #
+  def in_groups(number, fill_with = nil)
+    division = size / number
+    modulo = size % number
+
+    groups = [] of Array(T | Nil | Bool)
+    start = 0
+
+    number.times do |index|
+      last_group = [] of T | Nil | Bool
+      length = division + (modulo > 0 && modulo > index ? 1 : 0)
+      self[start..(start + (length - 1))].each { |e| last_group << e }
+      groups << last_group
+      last_group.push(fill_with) if fill_with != false &&
+                                    modulo > 0 && length == division
+      start += length
+    end
+    groups
+  end
+
+  def in_groups(number, fill_with = nil)
+    division = size / number
+    modulo = size % number
+
+    groups = [] of Array(T | Nil | Bool)
+    start = 0
+
+    number.times do |index|
+      last_group = [] of T | Nil | Bool
+      length = division + (modulo > 0 && modulo > index ? 1 : 0)
+      self[start..(start + (length - 1))].each { |e| last_group << e }
+      groups << last_group
+      last_group.push(fill_with) if fill_with != false &&
+                                    modulo > 0 && length == division
+      start += length
+    end
+    groups.each { |g| yield(g) }
+  end
 end

--- a/src/crystal_on_steroids/array.cr
+++ b/src/crystal_on_steroids/array.cr
@@ -179,21 +179,8 @@ class Array(T)
   end
 
   def in_groups(number, fill_with = nil)
-    division = size / number
-    modulo = size % number
+    groups = in_groups(number, fill_with)
 
-    groups = [] of Array(T | Nil | Bool)
-    start = 0
-
-    number.times do |index|
-      last_group = [] of T | Nil | Bool
-      length = division + (modulo > 0 && modulo > index ? 1 : 0)
-      self[start..(start + (length - 1))].each { |e| last_group << e }
-      groups << last_group
-      last_group.push(fill_with) if fill_with != false &&
-                                    modulo > 0 && length == division
-      start += length
-    end
     groups.each { |g| yield(g) }
   end
 end


### PR DESCRIPTION
  Splits or iterates over the array in +number+ of groups, padding any
  remaining slots with +fill_with+ unless it is +false+.
 
``` 
    %w(1 2 3 4 5 6 7 8 9 10).in_groups(3) {|group| p group}
    ["1", "2", "3", "4"]
    ["5", "6", "7", nil]
    ["8", "9", "10", nil]

    %w(1 2 3 4 5 6 7 8 9 10).in_groups(3, '&nbsp;') {|group| p group}
    ["1", "2", "3", "4"]
    ["5", "6", "7", "&nbsp;"]
    ["8", "9", "10", "&nbsp;"]
  
    %w(1 2 3 4 5 6 7).in_groups(3, false) {|group| p group}
    ["1", "2", "3"]
    ["4", "5"]
    ["6", "7"]
  ```